### PR TITLE
docker-compose.yaml: Replace CORE_LOGGING_LEVEL with FABRIC_LOGGING_SPEC

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Copyright IBM Corp All Rights Reserved
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+export PATH=$GOPATH/src/github.com/hyperledger/fabric/build/bin:${PWD}/../bin:${PWD}:$PATH
+export FABRIC_CFG_PATH=${PWD}
+CHANNEL_NAME=allarewelcome
+
+# remove previous crypto material and config transactions
+rm -fr config/*
+rm -fr crypto-config/*
+
+# generate crypto material
+cryptogen generate --config=./crypto-config.yaml
+if [ "$?" -ne 0 ]; then
+  echo "Failed to generate crypto material..."
+  exit 1
+fi
+
+# generate genesis block for orderer
+configtxgen -profile OneOrgOrdererGenesis -outputBlock ./config/genesis.block
+if [ "$?" -ne 0 ]; then
+  echo "Failed to generate orderer genesis block..."
+  exit 1
+fi
+
+# generate channel configuration transaction
+configtxgen -profile OneOrgChannel -outputCreateChannelTx ./config/allarewelcome.tx -channelID allarewelcome
+if [ "$?" -ne 0 ]; then
+  echo "Failed to generate channel configuration transaction..."
+  exit 1
+fi
+
+# generate anchor peer transaction
+configtxgen -profile OneOrgChannel -outputAnchorPeersUpdate ./config/Org1MSPanchors.tx -channelID allarewelcome -asOrg Org1MSP
+if [ "$?" -ne 0 ]; then
+  echo "Failed to generate anchor peer update for Org1MSP..."
+  exit 1
+fi
+
+
+sleep 5s
+
+set -ev
+
+# don't rewrite paths for Windows Git Bash users
+export MSYS_NO_PATHCONV=1
+
+docker-compose -f docker-compose.yml down
+
+docker-compose -f docker-compose.yml up -d ca.example.com orderer.example.com peer0.org1.example.com
+
+# wait for Hyperledger Fabric to start
+# incase of errors when running later commands, issue export FABRIC_START_TIMEOUT=<larger number>
+export FABRIC_START_TIMEOUT=10
+#echo ${FABRIC_START_TIMEOUT}
+sleep ${FABRIC_START_TIMEOUT}
+
+# Create the channel
+docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" peer0.org1.example.com peer channel create -o orderer.example.com:7050 -c allarewelcome -f /etc/hyperledger/configtx/allarewelcome.tx
+# Join peer0.org1.example.com to the channel.
+docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" peer0.org1.example.com peer channel join -b allarewelcome.block

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
     environment:
       - GOPATH=/opt/gopath
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
-      - CORE_LOGGING_LEVEL=info
+      - FABRIC_LOGGING_SPEC=info
       - CORE_PEER_ID=cli
       - CORE_PEER_ADDRESS=peer0.org1.example.com:7051
       - CORE_PEER_LOCALMSPID=Org1MSP

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cd ~/Desktop
+curl -sSL http://bit.ly/2ysbOFE | bash -s 1.4.0
+sleep 10
+cd ./fabric-samples
+git clone https://github.com/kenmyatt-bta/startFiles.git
+sleep 10
+cd startFiles
+mkdir config
+wget https://s3.us-east-2.amazonaws.com/lfx-start1/bootstrap.sh
+chmod u+x ./bootstrap.sh
+chmod u+x start.sh teardown.sh stop.sh
+./bootstrap.sh
+
+sleep 30s
+
+rm ./bootstrap.sh ./startup.sh
+rm -- "$0"


### PR DESCRIPTION
1. In version 1.4 of fabric, the following warning is generated
'WARN 002 CORE_LOGGING_LEVEL is no longer supported, please use the FABRIC_LOGGING_SPEC environment variable'